### PR TITLE
feat: circle today's date

### DIFF
--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/common/Sizes.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/common/Sizes.kt
@@ -5,3 +5,7 @@ import androidx.compose.ui.unit.dp
 val SMALL_PADDING = 8.dp
 val MEDIUM_PADDING = 12.dp
 val LARGE_PADDING = 16.dp
+
+val THIN_BORDER = 2.dp
+
+val CIRCLE_INDICATOR_FRACTION = 0.8f

--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
@@ -156,13 +156,7 @@ fun Day(
                 Text(
                     text = day.date.dayOfMonth.toString(),
                     style = MaterialTheme.typography.bodyMedium,
-                    // Underline today's date
-                    textDecoration =
-                        if (isToday) {
-                            TextDecoration.Underline
-                        } else {
-                            TextDecoration.None
-                        },
+                    textDecoration = TextDecoration.None,
                     color =
                         if (allowedDate) {
                             MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
@@ -1,5 +1,6 @@
 package com.dessalines.habitmaker.ui.components.habit.habitanddetails.calendars
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -7,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.dessalines.habitmaker.db.HabitCheck
 import com.dessalines.habitmaker.db.sampleHabitChecks
 import com.dessalines.habitmaker.ui.components.common.MEDIUM_PADDING
@@ -35,7 +36,6 @@ import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.TextStyle
 import java.util.Locale
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun HabitCalendar(
@@ -141,17 +141,17 @@ fun Day(
             Box(
                 contentAlignment = Alignment.Center,
                 modifier =
-                if (isToday) {
-                    Modifier
-                        .size(32.dp)
-                        .border(
-                            width = 2.dp,
-                            color = MaterialTheme.colorScheme.primary,
-                            shape = CircleShape,
-                        )
-                } else {
-                    Modifier
-                },
+                    if (isToday) {
+                        Modifier
+                            .size(32.dp)
+                            .border(
+                                width = 2.dp,
+                                color = MaterialTheme.colorScheme.primary,
+                                shape = CircleShape,
+                            )
+                    } else {
+                        Modifier
+                    },
             ) {
                 Text(
                     text = day.date.dayOfMonth.toString(),

--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Icon
@@ -32,6 +35,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.TextStyle
 import java.util.Locale
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun HabitCalendar(
@@ -134,23 +138,39 @@ fun Day(
                 contentDescription = null,
             )
         } else {
-            Text(
-                text = day.date.dayOfMonth.toString(),
-                style = MaterialTheme.typography.bodyMedium,
-                // Underline today's date
-                textDecoration =
-                    if (isToday) {
-                        TextDecoration.Underline
-                    } else {
-                        TextDecoration.None
-                    },
-                color =
-                    if (allowedDate) {
-                        MaterialTheme.colorScheme.onSurface
-                    } else {
-                        MaterialTheme.colorScheme.outline
-                    },
-            )
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier =
+                if (isToday) {
+                    Modifier
+                        .size(32.dp)
+                        .border(
+                            width = 2.dp,
+                            color = MaterialTheme.colorScheme.primary,
+                            shape = CircleShape,
+                        )
+                } else {
+                    Modifier
+                },
+            ) {
+                Text(
+                    text = day.date.dayOfMonth.toString(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    // Underline today's date
+                    textDecoration =
+                        if (isToday) {
+                            TextDecoration.Underline
+                        } else {
+                            TextDecoration.None
+                        },
+                    color =
+                        if (allowedDate) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.outline
+                        },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -24,9 +24,9 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import com.dessalines.habitmaker.db.HabitCheck
 import com.dessalines.habitmaker.db.sampleHabitChecks
+import com.dessalines.habitmaker.ui.components.common.CIRCLE_INDICATOR_FRACTION
 import com.dessalines.habitmaker.ui.components.common.MEDIUM_PADDING
 import com.dessalines.habitmaker.ui.components.common.THIN_BORDER
-import com.dessalines.habitmaker.ui.components.common.CIRCLE_INDICATOR_FRACTION
 import com.dessalines.habitmaker.utils.epochMillisToLocalDate
 import com.kizitonwose.calendar.compose.HorizontalCalendar
 import com.kizitonwose.calendar.compose.rememberCalendarState

--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -24,10 +22,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.dessalines.habitmaker.db.HabitCheck
 import com.dessalines.habitmaker.db.sampleHabitChecks
 import com.dessalines.habitmaker.ui.components.common.MEDIUM_PADDING
+import com.dessalines.habitmaker.ui.components.common.THIN_BORDER
+import com.dessalines.habitmaker.ui.components.common.CIRCLE_INDICATOR_FRACTION
 import com.dessalines.habitmaker.utils.epochMillisToLocalDate
 import com.kizitonwose.calendar.compose.HorizontalCalendar
 import com.kizitonwose.calendar.compose.rememberCalendarState
@@ -145,10 +144,9 @@ fun Day(
                 modifier =
                     if (isToday) {
                         Modifier
-                            .fillMaxSize()
-                            .padding(4.dp)
+                            .fillMaxSize(CIRCLE_INDICATOR_FRACTION)
                             .border(
-                                width = 2.dp,
+                                width = THIN_BORDER,
                                 color = MaterialTheme.colorScheme.primary,
                                 shape = CircleShape,
                             )

--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/calendars/HabitCalendar.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -143,7 +145,8 @@ fun Day(
                 modifier =
                     if (isToday) {
                         Modifier
-                            .size(32.dp)
+                            .fillMaxSize()
+                            .padding(4.dp)
                             .border(
                                 width = 2.dp,
                                 color = MaterialTheme.colorScheme.primary,


### PR DESCRIPTION
## Summary

Add circle around today's date. An underline isn't as visually obvious. 

## Screenshot

<img src="https://github.com/user-attachments/assets/4ff9ebee-0930-4fb4-b302-7b7ded26d8b2" alt="screen_1" height="300" />
<img src="https://github.com/user-attachments/assets/8ae4c469-076f-476c-9c31-0c870d5d5035" alt="screen_2" height="300" />

