### PR TITLE
Fixing wearOS update syncing by combining.

### DIFF
--- a/app/src/fdroid/java/com/dessalines/habitmaker/MainActivity.kt
+++ b/app/src/fdroid/java/com/dessalines/habitmaker/MainActivity.kt
@@ -142,7 +142,6 @@ class MainActivity : AppCompatActivity() {
                     updateStatsForHabit(
                         habit = habit,
                         habitViewModel = habitViewModel,
-                        updateDataClient = false,
                         checks = checks,
                         completedCount = completedCount,
                         firstDayOfWeek = settings.firstDayOfWeek,
@@ -193,7 +192,6 @@ fun BroadcastReceivers(
                     updateStatsForHabit(
                         habit = habit,
                         habitViewModel = habitViewModel,
-                        updateDataClient = true,
                         checks = checks,
                         completedCount = completedCount,
                         firstDayOfWeek = firstDayOfWeek,

--- a/app/src/fdroid/java/com/dessalines/habitmaker/db/viewmodels/HabitCheckViewModel.kt
+++ b/app/src/fdroid/java/com/dessalines/habitmaker/db/viewmodels/HabitCheckViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.dessalines.habitmaker.db.HabitCheckDelete
 import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitCheckRepository
+import com.dessalines.habitmaker.db.HabitUpdateStats
 
 class HabitCheckViewModel(
     private val repository: HabitCheckRepository,
@@ -18,8 +19,27 @@ class HabitCheckViewModel(
         return insertedId
     }
 
+    /**
+     * Stub: this does nothing
+     */
+    fun sendHabitCheckInsertAndStatsUpdate(
+        insertedId: Long,
+        habitCheck: HabitCheckInsert,
+        stats: HabitUpdateStats,
+    ) {
+    }
+
     fun deleteForDay(habitCheck: HabitCheckDelete) {
         repository.deleteForDay(habitCheck)
+    }
+
+    /**
+     * Stub: this does nothing
+     */
+    fun sendHabitCheckDeleteAndStatsUpdate(
+        habitCheckDelete: HabitCheckDelete,
+        stats: HabitUpdateStats,
+    ) {
     }
 }
 

--- a/app/src/fdroid/java/com/dessalines/habitmaker/db/viewmodels/HabitViewModel.kt
+++ b/app/src/fdroid/java/com/dessalines/habitmaker/db/viewmodels/HabitViewModel.kt
@@ -32,12 +32,10 @@ class HabitViewModel(
             repository.update(habit)
         }
 
-    fun updateStats(
-        habit: HabitUpdateStats,
-        updateDataClient: Boolean,
-    ) = viewModelScope.launch {
-        repository.updateStats(habit)
-    }
+    fun updateStats(habit: HabitUpdateStats) =
+        viewModelScope.launch {
+            repository.updateStats(habit)
+        }
 
     fun delete(habit: Habit) =
         viewModelScope.launch {

--- a/app/src/full/java/com/dessalines/habitmaker/MainActivity.kt
+++ b/app/src/full/java/com/dessalines/habitmaker/MainActivity.kt
@@ -3,7 +3,6 @@ package com.dessalines.habitmaker
 import android.app.Application
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -13,9 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.asLiveData
@@ -25,6 +21,8 @@ import com.dessalines.habitmaker.db.AppDB
 import com.dessalines.habitmaker.db.AppSettings
 import com.dessalines.habitmaker.db.AppSettingsRepository
 import com.dessalines.habitmaker.db.EncouragementRepository
+import com.dessalines.habitmaker.db.HabitCheckDelete
+import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitCheckRepository
 import com.dessalines.habitmaker.db.HabitReminderRepository
 import com.dessalines.habitmaker.db.HabitRepository
@@ -41,7 +39,6 @@ import com.dessalines.habitmaker.db.viewmodels.HabitReminderViewModel
 import com.dessalines.habitmaker.db.viewmodels.HabitReminderViewModelFactory
 import com.dessalines.habitmaker.db.viewmodels.HabitViewModel
 import com.dessalines.habitmaker.db.viewmodels.HabitViewModelFactory
-import com.dessalines.habitmaker.flavorutils.isAvailable
 import com.dessalines.habitmaker.notifications.CANCEL_HABIT_INTENT_ACTION
 import com.dessalines.habitmaker.notifications.CANCEL_HABIT_INTENT_HABIT_ID
 import com.dessalines.habitmaker.notifications.CHECK_HABIT_INTENT_ACTION
@@ -54,7 +51,6 @@ import com.dessalines.habitmaker.ui.components.Main
 import com.dessalines.habitmaker.ui.components.habit.habitanddetails.checkHabitForDay
 import com.dessalines.habitmaker.ui.components.habit.habitanddetails.updateStatsForHabit
 import com.dessalines.habitmaker.ui.theme.HabitMakerTheme
-import com.dessalines.habitmaker.utils.TAG
 import com.dessalines.habitmaker.utils.getVersionCode
 import com.google.android.gms.wearable.Wearable
 import org.woheller69.freeDroidWarn.FreeDroidWarn
@@ -93,8 +89,6 @@ class MainActivity : AppCompatActivity() {
         HabitReminderViewModelFactory((application as HabitMakerApplication).habitReminderRepository)
     }
 
-    private val capabilityClient by lazy { Wearable.getCapabilityClient(this) }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         FreeDroidWarn.showWarningOnUpgrade(this, getVersionCode())
 
@@ -116,11 +110,8 @@ class MainActivity : AppCompatActivity() {
                 reminderViewModel,
             )
 
-            var apiAvailable by remember { mutableStateOf(false) }
             LaunchedEffect(Unit) {
                 updateHabitStatsOnStartup(ctx)
-                apiAvailable = isAvailable(capabilityClient)
-                Log.d(TAG, "Api available: $apiAvailable")
                 syncDBtoOtherDevices(
                     habitViewModel,
                     habitCheckViewModel,
@@ -163,7 +154,6 @@ class MainActivity : AppCompatActivity() {
                     updateStatsForHabit(
                         habit = habit,
                         habitViewModel = habitViewModel,
-                        updateDataClient = false,
                         checks = checks,
                         completedCount = completedCount,
                         firstDayOfWeek = settings.firstDayOfWeek,
@@ -209,16 +199,36 @@ fun BroadcastReceivers(
                 val isCompleted = isCompletedToday(habit.lastCompletedTime)
                 // Only check the habit if it hasn't been checked
                 if (!isCompleted) {
-                    checkHabitForDay(habitId, checkTime, habitCheckViewModel)
+                    val insertedId = checkHabitForDay(habitId, checkTime, habitCheckViewModel)
                     val checks = habitCheckViewModel.listForHabitSync(habitId)
-                    updateStatsForHabit(
-                        habit = habit,
-                        habitViewModel = habitViewModel,
-                        updateDataClient = true,
-                        checks = checks,
-                        completedCount = completedCount,
-                        firstDayOfWeek = firstDayOfWeek,
-                    )
+                    val stats =
+                        updateStatsForHabit(
+                            habit = habit,
+                            habitViewModel = habitViewModel,
+                            checks = checks,
+                            completedCount = completedCount,
+                            firstDayOfWeek = firstDayOfWeek,
+                        )
+                    if (insertedId == -1L) {
+                        habitCheckViewModel.sendHabitCheckDeleteAndStatsUpdate(
+                            habitCheckDelete =
+                                HabitCheckDelete(
+                                    habitId = habitId,
+                                    checkTime = checkTime,
+                                ),
+                            stats = stats,
+                        )
+                    } else {
+                        habitCheckViewModel.sendHabitCheckInsertAndStatsUpdate(
+                            insertedId = insertedId,
+                            habitCheck =
+                                HabitCheckInsert(
+                                    habitId = habitId,
+                                    checkTime = checkTime,
+                                ),
+                            stats = stats,
+                        )
+                    }
                 }
 
                 // Reschedule the reminders, to skip today

--- a/app/src/full/java/com/dessalines/habitmaker/datalayer/DataLayerListenerService.kt
+++ b/app/src/full/java/com/dessalines/habitmaker/datalayer/DataLayerListenerService.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.dessalines.habitmaker.db.AppDB
 import com.dessalines.habitmaker.db.Habit
-import com.dessalines.habitmaker.db.HabitCheckDelete
 import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitCheckRepository
 import com.dessalines.habitmaker.db.HabitInsert
@@ -13,10 +12,14 @@ import com.dessalines.habitmaker.db.HabitInsertWearable
 import com.dessalines.habitmaker.db.HabitRepository
 import com.dessalines.habitmaker.db.HabitUpdateStats
 import com.dessalines.habitmaker.db.utils.BulkInsert
+import com.dessalines.habitmaker.db.utils.HabitCheckDeleteAndStatsUpdate
+import com.dessalines.habitmaker.db.utils.HabitCheckInsertAndStatsUpdate
 import com.dessalines.habitmaker.db.viewmodels.HabitCheckViewModel
 import com.dessalines.habitmaker.db.viewmodels.HabitViewModel
-import com.dessalines.habitmaker.flavorutils.isAvailable
 import com.dessalines.habitmaker.utils.TAG
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.api.AvailabilityException
+import com.google.android.gms.common.api.GoogleApi
 import com.google.android.gms.wearable.DataClient
 import com.google.android.gms.wearable.DataEventBuffer
 import com.google.android.gms.wearable.DataMapItem
@@ -103,24 +106,21 @@ class DataLayerListenerService : WearableListenerService() {
                     habitRepository.insertWearable(habit)
                 }
 
-                "HabitUpdateStats" -> {
-                    val habit = Json.decodeFromString<HabitUpdateStats>(ungzip(event.data))
-                    habitRepository.updateStats(habit)
-                }
-
                 "HabitDelete" -> {
                     val habit = Json.decodeFromString<Habit>(ungzip(event.data))
                     habitRepository.delete(habit)
                 }
 
                 "HabitCheckInsert" -> {
-                    val habitCheck = Json.decodeFromString<HabitCheckInsert>(ungzip(event.data))
-                    habitCheckRepository.insert(habitCheck)
+                    val data = Json.decodeFromString<HabitCheckInsertAndStatsUpdate>(ungzip(event.data))
+                    habitCheckRepository.insert(data.check)
+                    habitRepository.updateStats(data.stats)
                 }
 
                 "HabitCheckDelete" -> {
-                    val habitCheck = Json.decodeFromString<HabitCheckDelete>(ungzip(event.data))
-                    habitCheckRepository.deleteForDay(habitCheck)
+                    val data = Json.decodeFromString<HabitCheckDeleteAndStatsUpdate>(ungzip(event.data))
+                    habitCheckRepository.deleteForDay(data.check)
+                    habitRepository.updateStats(data.stats)
                 }
             }
         }
@@ -218,3 +218,19 @@ fun gzip(content: String): ByteArray {
 }
 
 fun ungzip(content: ByteArray): String = GZIPInputStream(content.inputStream()).bufferedReader(UTF_8).use { it.readText() }
+
+private suspend fun isAvailable(api: GoogleApi<*>): Boolean =
+    try {
+        GoogleApiAvailability
+            .getInstance()
+            .checkApiAvailability(api)
+            .await()
+
+        true
+    } catch (_: AvailabilityException) {
+        Log.d(
+            TAG,
+            "${api.javaClass.simpleName} API is not available in this device.",
+        )
+        false
+    }

--- a/app/src/full/java/com/dessalines/habitmaker/db/viewmodels/HabitCheckViewModel.kt
+++ b/app/src/full/java/com/dessalines/habitmaker/db/viewmodels/HabitCheckViewModel.kt
@@ -7,6 +7,9 @@ import com.dessalines.habitmaker.datalayer.sendDataToOtherDevices
 import com.dessalines.habitmaker.db.HabitCheckDelete
 import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitCheckRepository
+import com.dessalines.habitmaker.db.HabitUpdateStats
+import com.dessalines.habitmaker.db.utils.HabitCheckDeleteAndStatsUpdate
+import com.dessalines.habitmaker.db.utils.HabitCheckInsertAndStatsUpdate
 import com.google.android.gms.wearable.DataClient
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -23,17 +26,43 @@ class HabitCheckViewModel(
 
     fun insert(habitCheck: HabitCheckInsert): Long {
         val insertedId = repository.insert(habitCheck)
-        val inserted = habitCheck.copy(id = insertedId.toInt())
-        viewModelScope.launch {
-            dataClient.sendDataToOtherDevices(Json.encodeToString(inserted), "HabitCheckInsert")
-        }
+
         return insertedId
+    }
+
+    fun sendHabitCheckInsertAndStatsUpdate(
+        insertedId: Long,
+        habitCheck: HabitCheckInsert,
+        stats: HabitUpdateStats,
+    ) {
+        val inserted = habitCheck.copy(id = insertedId.toInt())
+        val data =
+            HabitCheckInsertAndStatsUpdate(
+                check = inserted,
+                stats = stats,
+            )
+
+        viewModelScope.launch {
+            dataClient.sendDataToOtherDevices(Json.encodeToString(data), "HabitCheckInsert")
+        }
     }
 
     fun deleteForDay(habitCheck: HabitCheckDelete) {
         repository.deleteForDay(habitCheck)
+    }
+
+    fun sendHabitCheckDeleteAndStatsUpdate(
+        habitCheckDelete: HabitCheckDelete,
+        stats: HabitUpdateStats,
+    ) {
+        val data =
+            HabitCheckDeleteAndStatsUpdate(
+                check = habitCheckDelete,
+                stats = stats,
+            )
+
         viewModelScope.launch {
-            dataClient.sendDataToOtherDevices(Json.encodeToString(habitCheck), "HabitCheckDelete")
+            dataClient.sendDataToOtherDevices(Json.encodeToString(data), "HabitCheckDelete")
         }
     }
 }

--- a/app/src/full/java/com/dessalines/habitmaker/db/viewmodels/HabitViewModel.kt
+++ b/app/src/full/java/com/dessalines/habitmaker/db/viewmodels/HabitViewModel.kt
@@ -41,15 +41,10 @@ class HabitViewModel(
             dataClient.sendDataToOtherDevices(Json.encodeToString(habit), "HabitUpdate")
         }
 
-    fun updateStats(
-        habit: HabitUpdateStats,
-        updateDataClient: Boolean,
-    ) = viewModelScope.launch {
-        repository.updateStats(habit)
-        if (updateDataClient) {
-            dataClient.sendDataToOtherDevices(Json.encodeToString(habit), "HabitUpdateStats")
+    fun updateStats(habit: HabitUpdateStats) =
+        viewModelScope.launch {
+            repository.updateStats(habit)
         }
-    }
 
     fun delete(habit: Habit) =
         viewModelScope.launch {

--- a/app/src/full/java/com/dessalines/habitmaker/flavorutils/FlavorUtils.kt
+++ b/app/src/full/java/com/dessalines/habitmaker/flavorutils/FlavorUtils.kt
@@ -6,19 +6,3 @@ import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.common.api.AvailabilityException
 import com.google.android.gms.common.api.GoogleApi
 import kotlinx.coroutines.tasks.await
-
-suspend fun isAvailable(api: GoogleApi<*>): Boolean =
-    try {
-        GoogleApiAvailability
-            .getInstance()
-            .checkApiAvailability(api)
-            .await()
-
-        true
-    } catch (_: AvailabilityException) {
-        Log.d(
-            TAG,
-            "${api.javaClass.simpleName} API is not available in this device.",
-        )
-        false
-    }

--- a/app/src/full/java/com/dessalines/habitmaker/flavorutils/FlavorUtils.kt
+++ b/app/src/full/java/com/dessalines/habitmaker/flavorutils/FlavorUtils.kt
@@ -1,8 +1,0 @@
-package com.dessalines.habitmaker.flavorutils
-
-import android.util.Log
-import com.dessalines.habitmaker.utils.TAG
-import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.common.api.AvailabilityException
-import com.google.android.gms.common.api.GoogleApi
-import kotlinx.coroutines.tasks.await

--- a/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/HabitsAndDetailScreen.kt
+++ b/app/src/main/java/com/dessalines/habitmaker/ui/components/habit/habitanddetails/HabitsAndDetailScreen.kt
@@ -145,17 +145,42 @@ fun HabitsAndDetailScreen(
                                 val habit = habits?.find { it.id == habitId }
                                 habit?.let { habit ->
                                     val checkTime = LocalDate.now().toEpochMillis()
-                                    checkHabitForDay(habitId, checkTime, habitCheckViewModel)
+                                    val insertedId =
+                                        checkHabitForDay(
+                                            habitId = habitId,
+                                            checkTime = checkTime,
+                                            habitCheckViewModel = habitCheckViewModel,
+                                        )
                                     val checks = habitCheckViewModel.listForHabitSync(habitId)
                                     val stats =
                                         updateStatsForHabit(
                                             habit = habit,
                                             habitViewModel = habitViewModel,
-                                            updateDataClient = true,
                                             checks = checks,
                                             completedCount = completedCount,
                                             firstDayOfWeek = firstDayOfWeek,
                                         )
+
+                                    if (insertedId == -1L) {
+                                        habitCheckViewModel.sendHabitCheckDeleteAndStatsUpdate(
+                                            habitCheckDelete =
+                                                HabitCheckDelete(
+                                                    habitId = habitId,
+                                                    checkTime = checkTime,
+                                                ),
+                                            stats = stats,
+                                        )
+                                    } else {
+                                        habitCheckViewModel.sendHabitCheckInsertAndStatsUpdate(
+                                            insertedId = insertedId,
+                                            habitCheck =
+                                                HabitCheckInsert(
+                                                    habitId = habitId,
+                                                    checkTime = checkTime,
+                                                ),
+                                            stats = stats,
+                                        )
+                                    }
 
                                     // If successful, show a random encouragement
                                     val isCompleted = isCompletedToday(stats.lastCompletedTime)
@@ -249,22 +274,44 @@ fun HabitsAndDetailScreen(
                                                     .atStartOfDay(ZoneId.systemDefault())
                                                     .toInstant()
                                                     .toEpochMilli()
-                                            checkHabitForDay(
-                                                habit.id,
-                                                checkTime,
-                                                habitCheckViewModel,
-                                            )
+                                            val insertedId =
+                                                checkHabitForDay(
+                                                    habitId = habit.id,
+                                                    checkTime = checkTime,
+                                                    habitCheckViewModel = habitCheckViewModel,
+                                                )
                                             val checks =
                                                 habitCheckViewModel.listForHabitSync(habitId)
                                             val stats =
                                                 updateStatsForHabit(
                                                     habit = habit,
                                                     habitViewModel = habitViewModel,
-                                                    updateDataClient = true,
                                                     checks = checks,
                                                     completedCount = completedCount,
                                                     firstDayOfWeek = firstDayOfWeek,
                                                 )
+
+                                            if (insertedId == -1L) {
+                                                habitCheckViewModel.sendHabitCheckDeleteAndStatsUpdate(
+                                                    habitCheckDelete =
+                                                        HabitCheckDelete(
+                                                            habitId = habitId,
+                                                            checkTime = checkTime,
+                                                        ),
+                                                    stats = stats,
+                                                )
+                                            } else {
+                                                habitCheckViewModel.sendHabitCheckInsertAndStatsUpdate(
+                                                    insertedId = insertedId,
+                                                    habitCheck =
+                                                        HabitCheckInsert(
+                                                            habitId = habitId,
+                                                            checkTime = checkTime,
+                                                        ),
+                                                    stats = stats,
+                                                )
+                                            }
+
                                             // Reschedule the reminders, to skip completed today
                                             val isCompleted = isCompletedToday(stats.lastCompletedTime)
                                             val reminders = reminderViewModel.listForHabitSync(habit.id)
@@ -298,7 +345,7 @@ fun checkHabitForDay(
     habitId: Int,
     checkTime: Long,
     habitCheckViewModel: HabitCheckViewModel,
-) {
+): Long {
     val data =
         HabitCheckInsert(
             habitId = habitId,
@@ -311,12 +358,12 @@ fun checkHabitForDay(
     if (success == -1L) {
         habitCheckViewModel.deleteForDay(HabitCheckDelete(habitId = habitId, checkTime = checkTime))
     }
+    return success
 }
 
 fun updateStatsForHabit(
     habit: Habit,
     habitViewModel: HabitViewModel,
-    updateDataClient: Boolean,
     checks: List<HabitCheck>,
     completedCount: Int,
     firstDayOfWeek: DayOfWeek,
@@ -348,7 +395,7 @@ fun updateStatsForHabit(
             lastCompletedTime = lastCompletedTime,
             completed = checks.size,
         )
-    habitViewModel.updateStats(statsUpdate, updateDataClient)
+    habitViewModel.updateStats(statsUpdate)
 
     return statsUpdate
 }

--- a/db/src/main/java/com/dessalines/habitmaker/db/utils/Utils.kt
+++ b/db/src/main/java/com/dessalines/habitmaker/db/utils/Utils.kt
@@ -1,5 +1,6 @@
 package com.dessalines.habitmaker.db.utils
 
+import com.dessalines.habitmaker.db.HabitCheckDelete
 import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitInsert
 import com.dessalines.habitmaker.db.HabitUpdateStats
@@ -48,4 +49,16 @@ fun HabitFrequency.toDays() =
 data class BulkInsert(
     val habitInserts: List<Pair<HabitInsert, HabitUpdateStats>>,
     val checkInserts: List<HabitCheckInsert>,
+)
+
+@Serializable
+data class HabitCheckInsertAndStatsUpdate(
+    val check: HabitCheckInsert,
+    val stats: HabitUpdateStats,
+)
+
+@Serializable
+data class HabitCheckDeleteAndStatsUpdate(
+    val check: HabitCheckDelete,
+    val stats: HabitUpdateStats,
 )

--- a/wearable/src/main/java/com/dessalines/habitmaker/datalayer/DataLayerListenerService.kt
+++ b/wearable/src/main/java/com/dessalines/habitmaker/datalayer/DataLayerListenerService.kt
@@ -4,14 +4,13 @@ import android.annotation.SuppressLint
 import android.util.Log
 import com.dessalines.habitmaker.db.AppDB
 import com.dessalines.habitmaker.db.Habit
-import com.dessalines.habitmaker.db.HabitCheckDelete
-import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitCheckRepository
 import com.dessalines.habitmaker.db.HabitInsert
 import com.dessalines.habitmaker.db.HabitRepository
 import com.dessalines.habitmaker.db.HabitUpdate
-import com.dessalines.habitmaker.db.HabitUpdateStats
 import com.dessalines.habitmaker.db.utils.BulkInsert
+import com.dessalines.habitmaker.db.utils.HabitCheckDeleteAndStatsUpdate
+import com.dessalines.habitmaker.db.utils.HabitCheckInsertAndStatsUpdate
 import com.dessalines.habitmaker.utils.TAG
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.common.api.AvailabilityException
@@ -107,24 +106,21 @@ class DataLayerListenerService : WearableListenerService() {
                     habitRepository.update(habit)
                 }
 
-                "HabitUpdateStats" -> {
-                    val habit = Json.decodeFromString<HabitUpdateStats>(ungzip(event.data))
-                    habitRepository.updateStats(habit)
-                }
-
                 "HabitDelete" -> {
                     val habit = Json.decodeFromString<Habit>(ungzip(event.data))
                     habitRepository.delete(habit)
                 }
 
                 "HabitCheckInsert" -> {
-                    val habitCheck = Json.decodeFromString<HabitCheckInsert>(ungzip(event.data))
-                    habitCheckRepository.insert(habitCheck)
+                    val data = Json.decodeFromString<HabitCheckInsertAndStatsUpdate>(ungzip(event.data))
+                    habitCheckRepository.insert(data.check)
+                    habitRepository.updateStats(data.stats)
                 }
 
                 "HabitCheckDelete" -> {
-                    val habitCheck = Json.decodeFromString<HabitCheckDelete>(ungzip(event.data))
-                    habitCheckRepository.deleteForDay(habitCheck)
+                    val data = Json.decodeFromString<HabitCheckDeleteAndStatsUpdate>(ungzip(event.data))
+                    habitCheckRepository.deleteForDay(data.check)
+                    habitRepository.updateStats(data.stats)
                 }
 
                 "BulkInsert" -> {

--- a/wearable/src/main/java/com/dessalines/habitmaker/db/viewmodels/HabitCheckViewModel.kt
+++ b/wearable/src/main/java/com/dessalines/habitmaker/db/viewmodels/HabitCheckViewModel.kt
@@ -7,6 +7,9 @@ import com.dessalines.habitmaker.datalayer.sendDataToOtherDevices
 import com.dessalines.habitmaker.db.HabitCheckDelete
 import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitCheckRepository
+import com.dessalines.habitmaker.db.HabitUpdateStats
+import com.dessalines.habitmaker.db.utils.HabitCheckDeleteAndStatsUpdate
+import com.dessalines.habitmaker.db.utils.HabitCheckInsertAndStatsUpdate
 import com.google.android.gms.wearable.DataClient
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -16,25 +19,46 @@ class HabitCheckViewModel(
 ) : ViewModel() {
     fun listForHabitSync(habitId: Int) = repository.listForHabitSync(habitId)
 
-    fun insert(
-        habitCheck: HabitCheckInsert,
-        dataClient: DataClient,
-    ): Long {
+    fun insert(habitCheck: HabitCheckInsert): Long {
         val insertedId = repository.insert(habitCheck)
-        val inserted = habitCheck.copy(id = insertedId.toInt())
-        viewModelScope.launch {
-            dataClient.sendDataToOtherDevices(Json.encodeToString(inserted), "HabitCheckInsert")
-        }
         return insertedId
     }
 
-    fun deleteForDay(
-        habitCheck: HabitCheckDelete,
+    fun sendHabitCheckInsertAndStatsUpdate(
         dataClient: DataClient,
+        insertedId: Long,
+        habitCheck: HabitCheckInsert,
+        stats: HabitUpdateStats,
     ) {
-        repository.deleteForDay(habitCheck)
+        val inserted = habitCheck.copy(id = insertedId.toInt())
+        val data =
+            HabitCheckInsertAndStatsUpdate(
+                check = inserted,
+                stats = stats,
+            )
+
         viewModelScope.launch {
-            dataClient.sendDataToOtherDevices(Json.encodeToString(habitCheck), "HabitCheckDelete")
+            dataClient.sendDataToOtherDevices(Json.encodeToString(data), "HabitCheckInsert")
+        }
+    }
+
+    fun deleteForDay(habitCheck: HabitCheckDelete) {
+        repository.deleteForDay(habitCheck)
+    }
+
+    fun sendHabitCheckDeleteAndStatsUpdate(
+        dataClient: DataClient,
+        habitCheckDelete: HabitCheckDelete,
+        stats: HabitUpdateStats,
+    ) {
+        val data =
+            HabitCheckDeleteAndStatsUpdate(
+                check = habitCheckDelete,
+                stats = stats,
+            )
+
+        viewModelScope.launch {
+            dataClient.sendDataToOtherDevices(Json.encodeToString(data), "HabitCheckDelete")
         }
     }
 }
@@ -62,18 +86,18 @@ fun checkHabitForDay(
     habitId: Int,
     checkTime: Long,
     habitCheckViewModel: HabitCheckViewModel,
-    dataClient: DataClient,
-) {
+): Long {
     val data =
         HabitCheckInsert(
             habitId = habitId,
             checkTime = checkTime,
         )
-    val success = habitCheckViewModel.insert(data, dataClient)
+    val success = habitCheckViewModel.insert(data)
 
     // If its -1, that means that its already been checked for today,
     // and you actually need to delete it to toggle
     if (success == -1L) {
-        habitCheckViewModel.deleteForDay(HabitCheckDelete(habitId, checkTime), dataClient)
+        habitCheckViewModel.deleteForDay(HabitCheckDelete(habitId, checkTime))
     }
+    return success
 }

--- a/wearable/src/main/java/com/dessalines/habitmaker/db/viewmodels/HabitViewModel.kt
+++ b/wearable/src/main/java/com/dessalines/habitmaker/db/viewmodels/HabitViewModel.kt
@@ -39,13 +39,10 @@ class HabitViewModel(
         return insertedId
     }
 
-    fun updateStats(
-        habit: HabitUpdateStats,
-        dataClient: DataClient,
-    ) = viewModelScope.launch {
-        repository.updateStats(habit)
-        dataClient.sendDataToOtherDevices(Json.encodeToString(habit), "HabitUpdateStats")
-    }
+    fun updateStats(habit: HabitUpdateStats) =
+        viewModelScope.launch {
+            repository.updateStats(habit)
+        }
 }
 
 class HabitViewModelFactory(
@@ -63,7 +60,6 @@ class HabitViewModelFactory(
 fun updateStatsForHabit(
     habit: Habit,
     habitViewModel: HabitViewModel,
-    dataClient: DataClient,
     checks: List<HabitCheck>,
     completedCount: Int,
     firstDayOfWeek: DayOfWeek,
@@ -95,7 +91,7 @@ fun updateStatsForHabit(
             lastCompletedTime = lastCompletedTime,
             completed = checks.size,
         )
-    habitViewModel.updateStats(statsUpdate, dataClient)
+    habitViewModel.updateStats(statsUpdate)
 
     return statsUpdate
 }

--- a/wearable/src/main/java/com/dessalines/habitmaker/ui/components/habit/HabitsScreen.kt
+++ b/wearable/src/main/java/com/dessalines/habitmaker/ui/components/habit/HabitsScreen.kt
@@ -49,6 +49,8 @@ import androidx.wear.input.wearableExtender
 import com.dessalines.habitmaker.R
 import com.dessalines.habitmaker.db.AppSettings
 import com.dessalines.habitmaker.db.Habit
+import com.dessalines.habitmaker.db.HabitCheckDelete
+import com.dessalines.habitmaker.db.HabitCheckInsert
 import com.dessalines.habitmaker.db.HabitInsertWearable
 import com.dessalines.habitmaker.db.utils.HabitGroupData
 import com.dessalines.habitmaker.db.utils.buildHabitsByFrequency
@@ -135,21 +137,44 @@ fun HabitsScreen(
                     transformationSpec = transformationSpec,
                     onCheck = { habit ->
                         val checkTime = LocalDate.now().toEpochMillis()
-                        checkHabitForDay(
-                            habit.id,
-                            checkTime,
-                            habitCheckViewModel,
-                            dataClient,
-                        )
+                        val insertedId =
+                            checkHabitForDay(
+                                habitId = habit.id,
+                                checkTime = checkTime,
+                                habitCheckViewModel = habitCheckViewModel,
+                            )
                         val checks = habitCheckViewModel.listForHabitSync(habit.id)
-                        updateStatsForHabit(
-                            habit,
-                            habitViewModel,
-                            dataClient,
-                            checks,
-                            completedCount,
-                            firstDayOfWeek,
-                        )
+                        val stats =
+                            updateStatsForHabit(
+                                habit,
+                                habitViewModel,
+                                checks,
+                                completedCount,
+                                firstDayOfWeek,
+                            )
+
+                        if (insertedId == -1L) {
+                            habitCheckViewModel.sendHabitCheckDeleteAndStatsUpdate(
+                                dataClient = dataClient,
+                                habitCheckDelete =
+                                    HabitCheckDelete(
+                                        habitId = habit.id,
+                                        checkTime = checkTime,
+                                    ),
+                                stats = stats,
+                            )
+                        } else {
+                            habitCheckViewModel.sendHabitCheckInsertAndStatsUpdate(
+                                dataClient = dataClient,
+                                insertedId = insertedId,
+                                habitCheck =
+                                    HabitCheckInsert(
+                                        habitId = habit.id,
+                                        checkTime = checkTime,
+                                    ),
+                                stats = stats,
+                            )
+                        }
 
                         updateComplication(ctx)
                     },


### PR DESCRIPTION
DataClient can't seem to handle two simultaneous sends reliably, so this combines the check / delete check, with the stats update.